### PR TITLE
docs: make optional retry/backoff task visible in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,5 +68,3 @@ In simple words, you should be able to say:
 ### Optional (recommended)
 
 1. [Advanced agent features](./lab/tasks/optional/task-1.md#advanced-agent-features)
-   - Includes **retry logic with backoff** for 429/5xx LLM API errors.
-   - Highly recommended if you use free-tier models (rate limits happen often).

--- a/lab/tasks/required/task-1.md
+++ b/lab/tasks/required/task-1.md
@@ -59,6 +59,8 @@ Your agent needs an LLM that supports the OpenAI-compatible chat completions API
 
 [OpenRouter](https://openrouter.ai) offers free models with no credit card required. Look for models that support **tool calling** — you will need this in Task 2.
 
+> **Tip:** Free-tier models can hit rate limits (`429`) and occasional `5xx` errors. Keep this in mind when designing your agent and see [Optional Task 1](../optional/task-1.md#advanced-agent-features) for retry logic with backoff.
+
 Store your LLM key in `.env.agent.secret` (gitignored by the `*.secret` pattern). An example file is provided:
 
 ```bash


### PR DESCRIPTION
Adds visibility for the optional task in Lab 6 README:

- TOC now includes **Optional (recommended)**
- Tasks section now links to `lab/tasks/optional/task-1.md`
- Explicitly calls out retry/backoff for 429/5xx and recommends it for free-tier model usage

This keeps required flow unchanged while helping students discover reliability improvements.