### PR TITLE
Rename task 1: Basic Agent Loop → Call an LLM from Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,6 @@ In simple words, you should be able to say:
 
 ### Required
 
-1. [Basic agent loop](./lab/tasks/required/task-1.md#basic-agent-loop)
+1. [Call an LLM from code](./lab/tasks/required/task-1.md#call-an-llm-from-code)
 2. [Add tools](./lab/tasks/required/task-2.md#add-tools)
 3. [Pass the benchmark](./lab/tasks/required/task-3.md#pass-the-benchmark)

--- a/instructors/lab-plan.md
+++ b/instructors/lab-plan.md
@@ -41,7 +41,7 @@ A senior engineer explains the assignment:
 
 ## Required tasks
 
-### Task 1 — Basic Agent Loop
+### Task 1 — Call an LLM from Code
 
 **Purpose:**
 

--- a/lab/tasks/required/task-1.md
+++ b/lab/tasks/required/task-1.md
@@ -1,12 +1,12 @@
-# Basic Agent Loop
+# Call an LLM from Code
 
-Build a CLI agent that connects to an LLM and answers questions about the course.
+Build a CLI that connects to an LLM and answers questions about the course.
 
 ## [Git workflow](../../../wiki/git-workflow.md)
 
-1. Create an issue titled `[Task] Basic Agent Loop`.
+1. Create an issue titled `[Task] Call an LLM from Code`.
 2. Pull latest `main` from `origin` and `upstream`.
-3. Create a branch from `main` (e.g., `task/basic-agent-loop`).
+3. Create a branch from `main` (e.g., `task/call-an-llm-from-code`).
 4. Work on the branch. Commit as you go using [conventional commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `docs:`, `test:`).
 5. Push, create a PR to `main` in **your fork** (not upstream). Link the issue using a keyword (e.g., `Closes #1`).
 6. Get a review from your partner, merge (this closes the issue automatically), delete the branch.
@@ -82,7 +82,7 @@ Before writing code, create `plans/task-1.md`. Describe your plan:
 Commit:
 
 ```text
-docs: add implementation plan for basic agent loop
+docs: add implementation plan for LLM integration
 ```
 
 ### 2. Agent (`agent.py`)
@@ -100,7 +100,7 @@ Create `agent.py` in the project root. The agent must handle questions about the
 Commit:
 
 ```text
-feat: implement basic agent loop with LLM integration
+feat: implement LLM-powered agent CLI
 ```
 
 ### 3. Documentation (`AGENT.md`)


### PR DESCRIPTION
## Summary
- Rename task 1 from "Basic Agent Loop" to "Call an LLM from Code" — there is no loop in task 1, just a single LLM call
- Update issue title, branch name, commit messages in task-1.md
- Update README link and instructors/lab-plan.md

## Note
Autochecker spec rename is in a separate PR (autochecker repo).