### PR TITLE
fix: address blockers found during student walkthrough

### DIFF
--- a/instructors/lab-plan.md
+++ b/instructors/lab-plan.md
@@ -227,9 +227,9 @@ Autochecker (Hetzner, clone_and_run for task 3):
 
 | Model | Context | Tool calling | Notes |
 |-------|---------|-------------|-------|
-| `meta-llama/llama-4-scout:free` | 512k | Strong | Best free option |
-| `meta-llama/llama-3.3-70b-instruct:free` | 128k | Strong | Reliable fallback |
-| `qwen/qwen-2.5-72b-instruct:free` | 128k | Good | Alternative |
+| `meta-llama/llama-3.3-70b-instruct:free` | 128k | Strong | Default in `.env.agent.example` |
+| `mistralai/mistral-small-3.1-24b-instruct:free` | 96k | Strong | Good alternative |
+| `qwen/qwen3-coder:free` | 128k | Good | Alternative |
 
 **Configuration:** `.env.agent.secret` (gitignored), with `.env.agent.example` committed.
 
@@ -578,7 +578,7 @@ This is a better model of real-world debugging (errors are often silent to the u
 - [x] Add `check_tools` / tool chain checking to engine.
 - [x] Add exception handler in `main.py` for visible error responses.
 - [x] Write Class E questions (3 LLM-judged reasoning, bot-only).
-- [x] Add `llm_judge` checking to engine (uses OpenRouter, llama-4-scout:free).
+- [x] Add `llm_judge` checking to engine (uses OpenRouter, gemini-2.5-flash-lite).
 - [x] Deploy autochecker with Class D/E questions and LLM judge.
 
 **Remaining:**

--- a/lab/tasks/required/task-1.md
+++ b/lab/tasks/required/task-1.md
@@ -40,9 +40,12 @@ Your agent needs an LLM that supports the OpenAI-compatible chat completions API
 
 | Model | Tool calling | Notes |
 |-------|-------------|-------|
-| `meta-llama/llama-4-scout:free` | Strong | Best free option |
-| `meta-llama/llama-3.3-70b-instruct:free` | Strong | Reliable fallback |
-| `qwen/qwen-2.5-72b-instruct:free` | Good | Alternative |
+| `meta-llama/llama-3.3-70b-instruct:free` | Strong | Default in `.env.agent.example` |
+| `mistralai/mistral-small-3.1-24b-instruct:free` | Strong | Good alternative |
+| `qwen/qwen3-coder:free` | Good | Alternative |
+
+> [!TIP]
+> Free models change frequently on OpenRouter. Check the [free models collection](https://openrouter.ai/collections/free-models) for the latest list. Filter for models that support **tool calling** — you will need this in Tasks 2–3.
 
 Register in OpenRouter and get an API key from them. This will be your LLM_API_KEY in `.env.agent.secret` (gitignored by the `*.secret` pattern). An example file is provided:
 
@@ -55,10 +58,11 @@ Edit `.env.agent.secret` and fill in `LLM_API_KEY`, `LLM_API_BASE`, and `LLM_MOD
 > **Note:** This is **not** the same as `LMS_API_KEY` in `.env.docker.secret`. That one protects your backend LMS endpoints. `LLM_API_KEY` authenticates with your LLM provider.
 
 > [!WARNING]
-> Free-tier models on OpenRouter have a **50 requests per day** limit per account. Plan your testing carefully:
-> - Use short, focused test runs instead of running the full eval repeatedly.
-> - Consider creating multiple OpenRouter accounts if you hit the limit.
-> - Implement retry logic with backoff for `429` errors (see [Optional Task 1](../optional/task-1.md#advanced-agent-features)).
+> **Rate limits on free models:**
+> - Free-tier models have a **50 requests per day** limit per account.
+> - Free models can also be **temporarily unavailable** due to upstream provider load. If you get a `429` error with a message about "temporarily rate-limited upstream", it means the model is overloaded — not that you hit your daily limit. Try again later or switch to a different free model.
+> - Plan your testing carefully: use `run_eval.py --index N` to test one question at a time instead of running the full eval repeatedly.
+> - Do not run `run_eval.py` until you have completed all three required tasks. Each run uses 10 requests.
 
 ## Deliverables
 

--- a/lab/tasks/required/task-3.md
+++ b/lab/tasks/required/task-3.md
@@ -91,6 +91,8 @@ Fix the failing question, re-run, move on to the next one.
 | Tool called but returns an error | Bug in tool implementation | Fix the tool code, test it in isolation |
 | Tool called with wrong arguments | LLM misunderstands the schema | Clarify parameter descriptions |
 | Agent times out | Too many tool calls or slow LLM | Reduce max iterations, try a faster model |
+| Agent crashes with `AttributeError: 'NoneType'` | LLM returns `content: null` when it makes tool calls | Use `(msg.get("content") or "")` instead of `msg.get("content", "")` — the field is present but `null`, not missing |
+| Agent reads the same file in a loop | File is too large and gets truncated, LLM can't find the answer | Increase the content limit sent back to the LLM |
 | Answer is close but doesn't match | Phrasing doesn't contain expected keyword | Adjust system prompt to be more precise |
 
 ## Deliverables

--- a/lab/tasks/setup-simple.md
+++ b/lab/tasks/setup-simple.md
@@ -114,7 +114,15 @@ We refer to your fork as `fork` and to the original repo as `upstream`.
 
    <h4>Port conflict (<code>port is already allocated</code>)</h4>
 
-   [Clean up `Docker`](../../wiki/docker.md#clean-up-docker), then run the `docker compose up` command again.
+   Labs 5 and 6 use the same ports (42001, 42002, 42004). If you have Lab 5 containers running, stop them first:
+
+   ```terminal
+   cd ../se-toolkit-lab-5
+   docker compose --env-file .env.docker.secret down
+   cd ../se-toolkit-lab-6
+   ```
+
+   If that doesn't help, [clean up `Docker`](../../wiki/docker.md#clean-up-docker), then run the `docker compose up` command again.
 
    <h4>Containers exit immediately</h4>
 


### PR DESCRIPTION
## Summary

Did a full student walkthrough of Lab 6 (setup → Task 1 → Task 2 → Task 3 → eval). Found and fixed critical blockers:

- **Non-existent model**: `llama-4-scout:free` doesn't exist on OpenRouter — students get 404. Replaced with verified models.
- **Port conflict with Lab 5**: Labs 5 and 6 share ports 42001/42002/42004. Added explicit troubleshooting step.
- **Upstream rate limiting confusion**: Free models return 429 from provider congestion, not account limits. Students think their key is broken. Added clarification.
- **Premature eval runs**: Added guidance to not run `run_eval.py` until all 3 tasks are done (wastes 10 requests per run).
- **Debugging hints**: Added `content: null` crash and file re-reading loop to Task 3 debugging table.

## Files changed
- `lab/tasks/required/task-1.md` — model table, rate limit warning, eval timing
- `lab/tasks/setup-simple.md` — Lab 5 port conflict troubleshooting
- `lab/tasks/required/task-3.md` — two debugging table rows
- `instructors/lab-plan.md` — model references