### PR TITLE
Make Qwen Code API the primary LLM provider

### DIFF
--- a/.env.agent.example
+++ b/.env.agent.example
@@ -5,11 +5,18 @@
 # That key protects your LMS endpoints.
 # This file configures the LLM that powers your agent.
 
-# Your LLM provider API key (e.g., from OpenRouter)
+# Your LLM provider API key
+# For Qwen Code API: the QWEN_API_KEY you set in ~/qwen-code-oai-proxy/.env
+# For OpenRouter: your OpenRouter API key
 LLM_API_KEY=your-llm-api-key-here
 
-# API base URL (OpenAI-compatible chat completions endpoint)
-LLM_API_BASE=https://openrouter.ai/api/v1
+# API base URL (OpenAI-compatible endpoint)
+# Qwen Code API on your VM (replace <vm-ip> and <port>):
+LLM_API_BASE=http://<your-vm-ip>:<qwen-api-port>/v1
+# OpenRouter alternative:
+# LLM_API_BASE=https://openrouter.ai/api/v1
 
 # Model name
-LLM_MODEL=meta-llama/llama-3.3-70b-instruct:free
+LLM_MODEL=qwen3-coder-plus
+# OpenRouter alternative:
+# LLM_MODEL=meta-llama/llama-3.3-70b-instruct:free

--- a/lab/tasks/required/task-1.md
+++ b/lab/tasks/required/task-1.md
@@ -34,20 +34,34 @@ uv run agent.py "What does REST stand for?"
 
 Your agent needs an LLM that supports the OpenAI-compatible chat completions API. You are free to use any provider.
 
-[OpenRouter](https://openrouter.ai) offers free models with no credit card required. Look for models that support **tool calling** — you will need this in later tasks.
+**Recommended: [Qwen Code API](../../wiki/qwen.md#set-up-the-qwen-code-api-remote-machine)**
 
-**Recommended models** (free, reliable tool calling):
+[Qwen Code](../../wiki/qwen.md#what-is-qwen-code) provides **1000 free requests per day**, works from Russia, and requires no credit card. Follow the [setup instructions](../setup-simple.md#17-set-up-llm-access-qwen-code-api) to deploy it on your VM.
 
 | Model | Tool calling | Notes |
 |-------|-------------|-------|
-| `meta-llama/llama-3.3-70b-instruct:free` | Strong | Default in `.env.agent.example` |
-| `mistralai/mistral-small-3.1-24b-instruct:free` | Strong | Good alternative |
+| `qwen3-coder-plus` | Strong | Recommended, default in `.env.agent.example` |
+| `coder-model` | Strong | Qwen 3.5 Plus |
+
+<details><summary><b>Alternative: OpenRouter (click to open)</b></summary>
+
+[OpenRouter](https://openrouter.ai) offers free models with no credit card required.
+
+| Model | Tool calling | Notes |
+|-------|-------------|-------|
+| `meta-llama/llama-3.3-70b-instruct:free` | Strong | Good alternative |
 | `qwen/qwen3-coder:free` | Good | Alternative |
 
-> [!TIP]
-> Free models change frequently on OpenRouter. Check the [free models collection](https://openrouter.ai/collections/free-models) for the latest list. Filter for models that support **tool calling** — you will need this in Tasks 2–3.
+> [!WARNING]
+> **OpenRouter free-tier limitations:**
+> - Free models have a **50 requests per day** limit per account.
+> - Free models can be **temporarily unavailable** due to upstream provider load (`429` errors).
+> - The autochecker runs 20 questions against your agent — free-tier rate limits may cause failures.
+> - If you use OpenRouter, plan your testing carefully: use `run_eval.py --index N` to test one question at a time.
 
-Register in OpenRouter and get an API key from them. This will be your LLM_API_KEY in `.env.agent.secret` (gitignored by the `*.secret` pattern). An example file is provided:
+</details>
+
+Create the agent environment file:
 
 ```bash
 cp .env.agent.example .env.agent.secret
@@ -56,13 +70,6 @@ cp .env.agent.example .env.agent.secret
 Edit `.env.agent.secret` and fill in `LLM_API_KEY`, `LLM_API_BASE`, and `LLM_MODEL`. Your agent reads from this file.
 
 > **Note:** This is **not** the same as `LMS_API_KEY` in `.env.docker.secret`. That one protects your backend LMS endpoints. `LLM_API_KEY` authenticates with your LLM provider.
-
-> [!WARNING]
-> **Rate limits on free models:**
-> - Free-tier models have a **50 requests per day** limit per account.
-> - Free models can also be **temporarily unavailable** due to upstream provider load. If you get a `429` error with a message about "temporarily rate-limited upstream", it means the model is overloaded — not that you hit your daily limit. Try again later or switch to a different free model.
-> - Plan your testing carefully: use `run_eval.py --index N` to test one question at a time instead of running the full eval repeatedly.
-> - Do not run `run_eval.py` until you have completed all three required tasks. Each run uses 10 requests.
 
 ## Deliverables
 

--- a/lab/tasks/setup-simple.md
+++ b/lab/tasks/setup-simple.md
@@ -6,7 +6,9 @@
   - [1.3. Start the services locally](#13-start-the-services-locally)
   - [1.4. Populate the database](#14-populate-the-database)
   - [1.5. Verify the local deployment](#15-verify-the-local-deployment)
-  - [1.6. Coding agent](#16-coding-agent)
+  - [1.6. Deploy to your VM](#16-deploy-to-your-vm)
+  - [1.7. Set up LLM access (Qwen Code API)](#17-set-up-llm-access-qwen-code-api)
+  - [1.8. Coding agent](#18-coding-agent)
 
 ## 1. Required steps
 
@@ -184,7 +186,106 @@ The database starts empty. You need to run the ETL pipeline to populate it with 
 > - You entered the correct API key in the frontend
 > - Try selecting a different lab in the dropdown (e.g., `lab-04`)
 
-### 1.6. Coding agent
+### 1.6. Deploy to your VM
+
+The autochecker tests your agent against your **deployed backend on your VM**. You need to deploy the same services there.
+
+1. [Connect to the VM](../../wiki/ssh.md#connect-to-the-vm).
+
+2. Clone your fork on the VM:
+
+   ```terminal
+   git clone https://github.com/<your-github-username>/se-toolkit-lab-6 ~/se-toolkit-lab-6
+   ```
+
+3. Create the environment file:
+
+   ```terminal
+   cd ~/se-toolkit-lab-6
+   cp .env.docker.example .env.docker.secret
+   ```
+
+4. Edit `.env.docker.secret` — set the same credentials as in your local file:
+
+   ```terminal
+   nano .env.docker.secret
+   ```
+
+   Set `AUTOCHECKER_EMAIL`, `AUTOCHECKER_PASSWORD`, and `LMS_API_KEY` (use the same values as locally).
+
+5. Start the services:
+
+   ```terminal
+   docker compose --env-file .env.docker.secret up --build -d
+   ```
+
+6. Populate the database:
+
+   ```terminal
+   curl -X POST http://localhost:42002/pipeline/sync \
+     -H "Authorization: Bearer <your-LMS_API_KEY>" \
+     -H "Content-Type: application/json" \
+     -d '{}'
+   ```
+
+7. Verify the deployment:
+
+   ```terminal
+   curl -s http://localhost:42002/items/ -H "Authorization: Bearer <your-LMS_API_KEY>" | head -c 200
+   ```
+
+   You should see a JSON array of items.
+
+> [!IMPORTANT]
+> Keep the services running on your VM. The autochecker will query your backend during evaluation.
+
+### 1.7. Set up LLM access (Qwen Code API)
+
+Your agent needs an LLM to answer questions. [Qwen Code](../../wiki/qwen.md#what-is-qwen-code) provides **1000 free requests per day** and works from Russia — no VPN or credit card needed.
+
+1. [Set up the Qwen Code API on your VM](../../wiki/qwen.md#set-up-the-qwen-code-api-remote-machine).
+
+   After completing the setup, you will have the Qwen API running on your VM at `http://localhost:<qwen-api-port>/v1`.
+
+2. On your **local machine**, create the agent environment file:
+
+   ```terminal
+   cp .env.agent.example .env.agent.secret
+   ```
+
+3. Edit `.env.agent.secret`:
+
+   ```text
+   LLM_API_KEY=<your-QWEN_API_KEY>
+   LLM_API_BASE=http://<your-vm-ip-address>:<qwen-api-port>/v1
+   LLM_MODEL=qwen3-coder-plus
+   ```
+
+   Replace `<your-QWEN_API_KEY>`, `<your-vm-ip-address>`, and `<qwen-api-port>` with your values.
+
+4. Verify the connection from your local machine:
+
+   ```terminal
+   curl -s http://<your-vm-ip-address>:<qwen-api-port>/v1/chat/completions \
+     -H "Content-Type: application/json" \
+     -H "Authorization: Bearer <your-QWEN_API_KEY>" \
+     -d '{"model":"qwen3-coder-plus","messages":[{"role":"user","content":"What is 2+2?"}]}' \
+     | python -m json.tool
+   ```
+
+<details><summary><b>Alternative: OpenRouter (click to open)</b></summary>
+
+If you prefer [OpenRouter](https://openrouter.ai), register and get an API key. Then set in `.env.agent.secret`:
+
+```text
+LLM_API_KEY=<your-openrouter-key>
+LLM_API_BASE=https://openrouter.ai/api/v1
+LLM_MODEL=meta-llama/llama-3.3-70b-instruct:free
+```
+
+</details>
+
+### 1.8. Coding agent
 
 > [!NOTE]
 > You should already have a coding agent from Lab 5.


### PR DESCRIPTION
## Summary
- **setup-simple**: Added VM deployment (1.6) and Qwen Code API setup (1.7) sections
- **task-1**: Qwen Code API is now the recommended provider; OpenRouter moved to collapsed fallback with rate limit warnings
- **.env.agent.example**: Defaults to Qwen Code API config instead of OpenRouter

## Why
OpenRouter free tier has 50 requests/day and frequent 429 errors. The autochecker runs 20 questions per eval — free-tier students hit rate limits consistently. Qwen Code API provides 1000 free requests/day and works from Russia without VPN.

## Test plan
- [ ] Verify Qwen Code API setup instructions match wiki/qwen.md
- [ ] Verify VM deployment steps work end-to-end
- [ ] Confirm `.env.agent.example` works with Qwen Code API