### PR TITLE
docs: add DNS troubleshooting for Docker

### DIFF
--- a/lab/tasks/setup-simple.md
+++ b/lab/tasks/setup-simple.md
@@ -140,6 +140,21 @@ We refer to your fork as `fork` and to the original repo as `upstream`.
    docker compose --env-file .env.docker.secret up --build -d
    ```
 
+   <h4>DNS resolution errors (<code>getaddrinfo EAI_AGAIN</code>)</h4>
+
+   If you see DNS errors like `getaddrinfo EAI_AGAIN registry.npmjs.org`, Docker can't resolve domain names. This is a university network DNS issue. Add Google DNS to Docker:
+
+   ```terminal
+   sudo tee /etc/docker/daemon.json <<'EOF'
+   {
+     "dns": ["8.8.8.8", "8.8.4.4"]
+   }
+   EOF
+   sudo systemctl restart docker
+   ```
+
+   Then run the `docker compose up` command again.
+
    </details>
 
 ### 1.4. Populate the database


### PR DESCRIPTION
## Summary
- Add DNS resolution troubleshooting (`getaddrinfo EAI_AGAIN`) to setup-simple.md
- Students on university network need to configure Google DNS in Docker daemon

## Test plan
- [ ] Verify the troubleshooting section renders correctly in GitHub