### PR TITLE
fix: numeric regex matching lone dots in run_eval

### DIFF
--- a/run_eval.py
+++ b/run_eval.py
@@ -147,13 +147,13 @@ def _match(text: str, rule: dict) -> bool:
         return bool(re.search(rule["regex"], text, re.IGNORECASE))
 
     if "numeric_gt" in rule:
-        numbers = re.findall(r"[\d.]+", text)
-        return any(float(n) > rule["numeric_gt"] for n in numbers if n)
+        numbers = re.findall(r"\d+(?:\.\d+)?", text)
+        return any(float(n) > rule["numeric_gt"] for n in numbers)
 
     if "numeric_range" in rule:
         lo, hi = rule["numeric_range"]
-        numbers = re.findall(r"[\d.]+", text)
-        return any(lo <= float(n) <= hi for n in numbers if n)
+        numbers = re.findall(r"\d+(?:\.\d+)?", text)
+        return any(lo <= float(n) <= hi for n in numbers)
 
     return False
 


### PR DESCRIPTION
## Summary
- The regex `[\d.]+` in `_match()` could match a standalone `.` (e.g. sentence-ending period), causing `ValueError: could not convert string to float: '.'`
- Changed to `\d+(?:\.\d+)?` which requires at least one digit

## Test plan
- [x] Verified regex handles `3.14`, `42`, lone `.`, and trailing periods correctly