### PR TITLE
fix: dashboard error handling, dynamic labs, conditional registry

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -1,5 +1,11 @@
 # See wiki/dotenv-docker-secret.md
 
+# Docker image registry prefix.
+# Default (university network): harbor cache proxy — avoids Docker Hub rate limits.
+# Outside university: set to empty to pull directly from Docker Hub.
+# REGISTRY_PREFIX=
+REGISTRY_PREFIX=harbor.pg.innopolis.university/docker-hub-cache/
+
 # app
 APP_NAME="Learning Management Service"
 APP_DEBUG=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,10 @@
 
 # First, build the application in the `/app` directory.
 # See `Dockerfile` for details.
-# A portable solution: download image from Docker Hub.
-# FROM astral/uv:python3.14-bookworm-slim AS builder
-
-# A less portable solution: download image through a cache proxy provided by the University.
-# This solution is necessary to avoid "Too many requests" errors.
-# This solution may not work outside of the University network.
-FROM harbor.pg.innopolis.university/docker-hub-cache/astral/uv:python3.14-bookworm-slim AS builder
+# REGISTRY_PREFIX: empty for Docker Hub, or university harbor cache.
+# Set via docker-compose build args or --build-arg.
+ARG REGISTRY_PREFIX=harbor.pg.innopolis.university/docker-hub-cache/
+FROM ${REGISTRY_PREFIX}astral/uv:python3.14-bookworm-slim AS builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 
 # Omit development dependencies
@@ -37,13 +34,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 
 # Then, use a final image without uv
-# A portable solution: download image from Docker Hub.
-# FROM python:3.14.2-slim-bookworm
-
-# A less portable solution: download image through a cache proxy provided by the University.
-# This solution is necessary to avoid "Too many requests" errors.
-# This solution may not work outside of the University network.
-FROM harbor.pg.innopolis.university/docker-hub-cache/python:3.14.2-slim-bookworm
+ARG REGISTRY_PREFIX=harbor.pg.innopolis.university/docker-hub-cache/
+FROM ${REGISTRY_PREFIX}python:3.14.2-slim-bookworm
 # It is important to use the image that matches the builder, as the path to the
 # Python executable must be the same, e.g., using `python:3.11-slim-bookworm`
 # will fail.

--- a/backend/app/routers/analytics.py
+++ b/backend/app/routers/analytics.py
@@ -209,7 +209,7 @@ async def get_completion_rate(
     )
     passed_learners = (await session.exec(passed_stmt)).one()
 
-    rate = (passed_learners / total_learners) * 100
+    rate = (passed_learners / total_learners) * 100 if total_learners else 0.0
 
     return {
         "lab": lab,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
 services:
   app:
-    build: .
+    build:
+      context: .
+      args:
+        REGISTRY_PREFIX: ${REGISTRY_PREFIX:-harbor.pg.innopolis.university/docker-hub-cache/}
     restart: unless-stopped
     ports:
       - ${APP_HOST_ADDRESS:?'APP_HOST_ADDRESS is required'}:${APP_HOST_PORT:?'APP_HOST_PORT is required'}:${APP_CONTAINER_PORT}
@@ -27,13 +30,7 @@ services:
         condition: service_healthy
 
   postgres:
-    # A portable solution: download image from Docker Hub.
-    # image: postgres:18.3-alpine
-
-    # A less portable solution: download image through a cache proxy provided by the University.
-    # This solution is necessary to avoid "Too many requests" errors.
-    # This solution may not work outside of the University network.
-    image: harbor.pg.innopolis.university/docker-hub-cache/postgres:18.3-alpine
+    image: ${REGISTRY_PREFIX:-harbor.pg.innopolis.university/docker-hub-cache/}postgres:18.3-alpine
     restart: unless-stopped
     environment:
       - POSTGRES_DB=${POSTGRES_DB:?'POSTGRES_DB is required'}
@@ -55,13 +52,7 @@ services:
       retries: 5
 
   pgadmin:
-    # A portable solution: download image from Docker Hub.
-    # image: dpage/pgadmin4:latest
-
-    # A less portable solution: download image through a cache proxy provided by the University.
-    # This solution is necessary to avoid "Too many requests" errors.
-    # This solution may not work outside of the University network.
-    image: harbor.pg.innopolis.university/docker-hub-cache/dpage/pgadmin4:latest
+    image: ${REGISTRY_PREFIX:-harbor.pg.innopolis.university/docker-hub-cache/}dpage/pgadmin4:latest
     restart: unless-stopped
     environment:
       - PGADMIN_DEFAULT_EMAIL=${PGADMIN_EMAIL:?'PGADMIN_EMAIL is required'}
@@ -73,7 +64,10 @@ services:
         condition: service_healthy
 
   caddy:
-    build: frontend/
+    build:
+      context: frontend/
+      args:
+        REGISTRY_PREFIX: ${REGISTRY_PREFIX:-harbor.pg.innopolis.university/docker-hub-cache/}
     depends_on:
       - app
     environment:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,11 +1,7 @@
 # Stage 1: Build the React frontend
-# A portable solution: download image from Docker Hub.
-# FROM node:22-alpine AS builder
-
-# A less portable solution: download image through a cache proxy provided by the University.
-# This solution is necessary to avoid "Too many requests" errors.
-# This solution may not work outside of the University network.
-FROM harbor.pg.innopolis.university/docker-hub-cache/node:25-alpine AS builder
+# REGISTRY_PREFIX: empty for Docker Hub, or university harbor cache.
+ARG REGISTRY_PREFIX=harbor.pg.innopolis.university/docker-hub-cache/
+FROM ${REGISTRY_PREFIX}node:25-alpine AS builder
 
 WORKDIR /app
 
@@ -18,12 +14,7 @@ RUN pnpm run build
 
 
 # Stage 2: Serve with Caddy
-# A portable solution: download image from Docker Hub.
-# FROM caddy:2.11-alpine
-
-# A less portable solution: download image through a cache proxy provided by the University.
-# This solution is necessary to avoid "Too many requests" errors.
-# This solution may not work outside of the University network.
-FROM harbor.pg.innopolis.university/docker-hub-cache/caddy:2.11-alpine
+ARG REGISTRY_PREFIX=harbor.pg.innopolis.university/docker-hub-cache/
+FROM ${REGISTRY_PREFIX}caddy:2.11-alpine
 
 COPY --from=builder /app/dist /srv

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -59,3 +59,57 @@ tr:nth-child(even) {
   padding: 0.25rem 0.75rem;
   font-size: 0.85rem;
 }
+
+/* Navigation */
+
+.nav-links {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.nav-links button {
+  padding: 0.4rem 1rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  background: #fff;
+  cursor: pointer;
+}
+
+.nav-links button.nav-active {
+  background: #3b82f6;
+  color: #fff;
+  border-color: #3b82f6;
+}
+
+/* Dashboard */
+
+.lab-selector {
+  margin-bottom: 1.5rem;
+}
+
+.lab-selector select {
+  padding: 0.4rem 0.5rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  margin-left: 0.5rem;
+}
+
+.charts-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.chart-card {
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.chart-card h3 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+  font-size: 1rem;
+}

--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -47,24 +47,59 @@ interface GroupEntry {
   students: number
 }
 
+interface ItemRecord {
+  id: number
+  type: string
+  title: string
+}
+
+async function checkedJson<T>(res: Response): Promise<T> {
+  if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`)
+  return res.json() as Promise<T>
+}
+
 function Dashboard({ token }: { token: string }) {
-  const [lab, setLab] = useState('lab-04')
+  const [labs, setLabs] = useState<string[]>([])
+  const [lab, setLab] = useState('')
   const [scores, setScores] = useState<ScoreBucket[]>([])
   const [passRates, setPassRates] = useState<PassRate[]>([])
   const [timeline, setTimeline] = useState<TimelineEntry[]>([])
   const [groups, setGroups] = useState<GroupEntry[]>([])
+  const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
 
+  // Fetch available labs dynamically from /items
   useEffect(() => {
     const headers = { Authorization: `Bearer ${token}` }
+    fetch('/items/', { headers })
+      .then((r) => checkedJson<ItemRecord[]>(r))
+      .then((items) => {
+        const labIds = items
+          .filter((i) => i.type === 'lab')
+          .map((i) => {
+            const m = i.title.match(/Lab\s+(\d+)/i)
+            return m ? `lab-${m[1].padStart(2, '0')}` : null
+          })
+          .filter((id): id is string => id !== null)
+          .sort()
+        setLabs(labIds)
+        if (labIds.length > 0 && !lab) setLab(labIds[labIds.length - 1])
+      })
+      .catch((err: Error) => setError(err.message))
+  }, [token])
+
+  useEffect(() => {
+    if (!lab) return
+    const headers = { Authorization: `Bearer ${token}` }
+    setLoading(true)
 
     Promise.all([
-      fetch(`/analytics/scores?lab=${lab}`, { headers }).then((r) => r.json()),
-      fetch(`/analytics/pass-rates?lab=${lab}`, { headers }).then((r) => r.json()),
-      fetch(`/analytics/timeline?lab=${lab}`, { headers }).then((r) => r.json()),
-      fetch(`/analytics/groups?lab=${lab}`, { headers }).then((r) => r.json()),
+      fetch(`/analytics/scores?lab=${lab}`, { headers }).then((r) => checkedJson<ScoreBucket[]>(r)),
+      fetch(`/analytics/pass-rates?lab=${lab}`, { headers }).then((r) => checkedJson<PassRate[]>(r)),
+      fetch(`/analytics/timeline?lab=${lab}`, { headers }).then((r) => checkedJson<TimelineEntry[]>(r)),
+      fetch(`/analytics/groups?lab=${lab}`, { headers }).then((r) => checkedJson<GroupEntry[]>(r)),
     ])
-      .then(([s, p, t, g]: [ScoreBucket[], PassRate[], TimelineEntry[], GroupEntry[]]) => {
+      .then(([s, p, t, g]) => {
         setScores(s)
         setPassRates(p)
         setTimeline(t)
@@ -72,9 +107,11 @@ function Dashboard({ token }: { token: string }) {
         setError('')
       })
       .catch((err: Error) => setError(err.message))
+      .finally(() => setLoading(false))
   }, [token, lab])
 
   if (error) return <p>Error loading analytics: {error}</p>
+  if (loading) return <p>Loading analytics...</p>
 
   const scoreData = {
     labels: scores.map((s) => s.bucket),
@@ -125,7 +162,7 @@ function Dashboard({ token }: { token: string }) {
       <div className="lab-selector">
         <label>Lab: </label>
         <select value={lab} onChange={(e) => setLab(e.target.value)}>
-          {['lab-01', 'lab-02', 'lab-03', 'lab-04', 'lab-05', 'lab-06'].map((l) => (
+          {labs.map((l) => (
             <option key={l} value={l}>
               {l}
             </option>


### PR DESCRIPTION
## Summary
- Dashboard.tsx: check `r.ok` before parsing JSON (prevent silent failures on 401/500)
- Dashboard.tsx: fetch lab list dynamically from `GET /items` instead of hardcoded `['lab-01'...'lab-06']`
- Dashboard.tsx: add loading state while fetching analytics
- App.css: add styles for `.nav-links`, `.lab-selector`, `.charts-grid`, `.chart-card`
- analytics.py: fix division by zero in `/analytics/completion-rate` when no interactions exist
- Dockerfiles + docker-compose.yml: `REGISTRY_PREFIX` build arg — defaults to university harbor cache, set empty for Docker Hub
- `.env.docker.example`: document `REGISTRY_PREFIX`

## Test plan
- [ ] `docker compose build` works with default (harbor)
- [ ] `REGISTRY_PREFIX= docker compose build` works (Docker Hub)
- [ ] Dashboard loads, lab dropdown is populated dynamically
- [ ] Switching labs shows loading indicator
- [ ] Charts render with grid layout
- [ ] `/analytics/completion-rate?lab=nonexistent` returns 0 instead of 500