### PR TITLE
feat(agent): add task 1 LLM CLI

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,64 @@
+# Agent Architecture
+
+## Overview
+
+`agent.py` is a minimal CLI agent for Task 1. It accepts a question as the first command-line argument, sends the question to an OpenAI-compatible chat completions API, and prints a single JSON object to stdout.
+
+## LLM Provider
+
+The agent uses Qwen Code API deployed on the VM.
+
+Current model:
+
+- `qwen3-coder-flash`
+
+## Configuration
+
+The agent reads these values from environment variables, with `.env.agent.secret` used as a local convenience file:
+
+- `LLM_API_KEY`
+- `LLM_API_BASE`
+- `LLM_MODEL`
+
+## Request Flow
+
+1. Parse the question from the CLI arguments.
+2. Load LLM configuration from the environment.
+3. Send a `POST` request to `<LLM_API_BASE>/chat/completions`.
+4. Request a short completion to reduce latency.
+5. Extract the assistant message from the API response.
+6. Print valid JSON to stdout:
+
+```json
+{"answer":"...","tool_calls":[]}
+```
+
+## Error Handling
+
+- Missing CLI argument: print to stderr and exit non-zero.
+- Missing or invalid environment variables: print to stderr and exit non-zero.
+- Failed API request or malformed API response: print to stderr and exit non-zero.
+
+## How To Run
+
+Create the environment file:
+
+```bash
+cp .env.agent.example .env.agent.secret
+```
+
+Fill in:
+
+- `LLM_API_KEY`
+- `LLM_API_BASE`
+- `LLM_MODEL`
+
+Run the agent:
+
+```bash
+uv run agent.py "What does REST stand for?"
+```
+
+## Testing
+
+The regression test runs `agent.py` as a subprocess, provides test LLM environment variables, parses stdout as JSON, and checks that the output contains `answer` and `tool_calls`.

--- a/agent.py
+++ b/agent.py
@@ -1,0 +1,100 @@
+import json
+import sys
+from typing import Any
+
+import httpx
+from pydantic import BaseModel
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    llm_api_key: str
+    llm_api_base: str
+    llm_model: str
+
+    model_config = SettingsConfigDict(
+        env_file=".env.agent.secret",
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+
+
+class AgentOutput(BaseModel):
+    answer: str
+    tool_calls: list[dict[str, Any]]
+
+
+def _parse_question(argv: list[str]) -> str:
+    if len(argv) < 2:
+        print("Usage: uv run agent.py \"<question>\"", file=sys.stderr)
+        sys.exit(1)
+
+    question = argv[1].strip()
+    if not question:
+        print("Question must not be empty.", file=sys.stderr)
+        sys.exit(1)
+
+    return question
+
+
+def _build_url(base_url: str) -> str:
+    return base_url.rstrip("/") + "/chat/completions"
+
+
+def _query_llm(question: str, settings: Settings) -> str:
+    payload = {
+        "model": settings.llm_model,
+        "max_tokens": 64,
+        "messages": [
+            {
+                "role": "system",
+                "content": "Answer the user's question in one short sentence.",
+            },
+            {"role": "user", "content": question},
+        ],
+    }
+
+    headers = {
+        "Authorization": f"Bearer {settings.llm_api_key}",
+        "Content-Type": "application/json",
+    }
+
+    try:
+        response = httpx.post(
+            _build_url(settings.llm_api_base),
+            headers=headers,
+            json=payload,
+            timeout=60.0,
+        )
+        response.raise_for_status()
+    except httpx.HTTPStatusError as error:
+        print(f"LLM API returned {error.response.status_code}: {error.response.text}", file=sys.stderr)
+        sys.exit(1)
+    except httpx.RequestError as error:
+        print(f"Cannot reach LLM API: {error}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        data = response.json()
+        return data["choices"][0]["message"]["content"].strip()
+    except (KeyError, IndexError, TypeError, ValueError) as error:
+        print(f"Invalid LLM response format: {error}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main() -> None:
+    question = _parse_question(sys.argv)
+
+    try:
+        settings = Settings()
+    except Exception as error:
+        print(f"Invalid LLM configuration: {error}", file=sys.stderr)
+        sys.exit(1)
+
+    answer = _query_llm(question, settings)
+    output = AgentOutput(answer=answer, tool_calls=[])
+    print(output.model_dump_json())
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/unit/test_agent_task1.py
+++ b/backend/tests/unit/test_agent_task1.py
@@ -1,0 +1,67 @@
+import json
+import os
+import subprocess
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+class _FakeLlmHandler(BaseHTTPRequestHandler):
+    def do_POST(self) -> None:  # noqa: N802
+        body = {
+            "id": "test-id",
+            "object": "chat.completion",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "Representational State Transfer.",
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+        }
+
+        encoded = json.dumps(body).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def log_message(self, format: str, *args: object) -> None:
+        return
+
+
+def test_agent_outputs_answer_and_tool_calls() -> None:
+    server = HTTPServer(("127.0.0.1", 0), _FakeLlmHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    env = os.environ.copy()
+    env["LLM_API_KEY"] = "test-key"
+    env["LLM_API_BASE"] = f"http://127.0.0.1:{server.server_port}/v1"
+    env["LLM_MODEL"] = "qwen3-coder-plus"
+
+    try:
+        result = subprocess.run(
+            [sys.executable, "agent.py", "What does REST stand for?"],
+            cwd=os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..")),
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=60,
+            check=False,
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1)
+
+    assert result.returncode == 0, result.stderr
+
+    data = json.loads(result.stdout)
+    assert "answer" in data
+    assert "tool_calls" in data
+    assert isinstance(data["tool_calls"], list)

--- a/plans/task-1.md
+++ b/plans/task-1.md
@@ -1,0 +1,39 @@
+# Task 1 Plan
+
+## Provider
+
+Use Qwen Code API deployed on the VM.
+
+## Model
+
+Use `qwen3-coder-flash`.
+
+## Configuration
+
+Read `LLM_API_KEY`, `LLM_API_BASE`, and `LLM_MODEL` from environment variables via `.env.agent.secret`.
+
+## CLI flow
+
+1. Read the question from the first command-line argument.
+2. Send a POST request to the OpenAI-compatible `/chat/completions` endpoint.
+3. Pass the question as a user message.
+4. Keep the completion short to reduce latency.
+5. Extract the assistant response text.
+6. Print JSON to stdout with `answer` and `tool_calls`.
+
+## Output
+
+The program returns:
+
+- `answer`: string
+- `tool_calls`: empty list
+
+## Error handling
+
+- Missing CLI argument -> print error to stderr and exit non-zero.
+- Missing environment variables -> print error to stderr and exit non-zero.
+- Failed HTTP request or invalid API response -> print error to stderr and exit non-zero.
+
+## Testing
+
+Create one regression test that runs `agent.py` as a subprocess, parses stdout JSON, and verifies `answer` and `tool_calls`.


### PR DESCRIPTION
## Summary

- Add a minimal CLI agent that calls an OpenAI-compatible LLM
- Document the Task 1 agent flow and configuration
- Add a regression test for the JSON output contract
- Closes #107 
